### PR TITLE
Cross browser compatibility and callbacks for animation.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,23 +65,19 @@ export function genericHashLink(props, As) {
       scrollFunction =
         props.scroll ||
         (el => {
-          if (!smooth) {
-            el.scrollIntoView();
-          } else {
-            if(props.onStartSmooth){
-              props.onStartSmooth();
-            }
-            jump(el.getBoundingClientRect().top - (props.offset || 0), {
-              callback: props.onEndSmooth,
-              easing: props.easing,
-              duration: props.duration
-            });
+          if (props.onStartScroll) {
+            props.onStartScroll();
           }
+          jump(el.getBoundingClientRect().top - (props.offset || 0), {
+            callback: props.onEndScroll,
+            easing: props.easing,
+            duration: smooth ? props.duration : 1
+          });
         });
       hashLinkScroll();
     }
   }
-  const { scroll, smooth, onStartSmooth, onEndSmooth, ...filteredProps } = props;
+  const { scroll, smooth, onStartScroll, onEndScroll, ...filteredProps } = props;
   return (
     <As {...filteredProps} onClick={handleClick}>
       {props.children}


### PR DESCRIPTION
I've noticed that IE, Edge and Safari are not executing the smooth animation because they don't accept options in the scrollIntoView method.

So I took a cross browser smooth function from [here](https://github.com/sitepoint-editors/smooth-scrolling) and modified it a little bit. Now it works in all modern browsern + IE >= 10.

Additionally I needed callbacks for the start and end of a smooth animation. scrollIntoView doesn't support those but the new function does.

It also accepts an offset as a parameter. A custom ease function is also possible.