### PR TITLE
Support for '#' and '#top' values

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,13 @@ const MyComponent = () => (
 );
 ```
 
+### Scroll to the top of the page
+
+Set `to` parameter to `#` or `#top` in order to scroll to the top of the page. You may also prevent URL update by preventing link default behaviour in `onClick` handler:
+
+```js
+import { HashLink as Link } from 'react-router-hash-link';
+<Link to="#top" onClick={e => e.preventDefault()}>
+  Link to Hash Fragment
+</Link>;
+```

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,13 @@ function reset() {
 }
 
 function getElAndScroll() {
-  const element = document.getElementById(hashFragment);
+  let element = null;
+  if (hashFragment === '#' || hashFragment === '#top') {
+    element = document.body;
+  } else {
+    const id = hashFragment.replace(/^#/, '');
+    element = document.getElementById(id);
+  }
   if (element !== null) {
     scrollFunction(element);
     reset();
@@ -50,18 +56,8 @@ export function genericHashLink(props, As) {
   function handleClick(e) {
     reset();
     if (props.onClick) props.onClick(e);
-    if (typeof props.to === 'string') {
-      hashFragment = props.to
-        .split('#')
-        .slice(1)
-        .join('#');
-    } else if (
-      typeof props.to === 'object' &&
-      typeof props.to.hash === 'string'
-    ) {
-      hashFragment = props.to.hash.replace('#', '');
-    }
-    if (hashFragment !== '') {
+    hashFragment = props.to.hash || props.to;
+    if (hashFragment !== "") {
       scrollFunction =
         props.scroll ||
         (el =>


### PR DESCRIPTION
Hi! 
I've really enjoyed using `react-router-hash-link` in one of my projects! 
I needed to make scroll to the top of the page and found that `#` and `#top` values are part of the HTML5 standard (according to the [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-href)). Hope this fix can help someone else 😃 
Thanks!