### PR TITLE
prefix prop for custom id

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ import { HashLink as Link } from 'react-router-hash-link';
 >Link to Hash Fragment</Link>
 ```
 
-### Custom `Link`
+## Custom `Link`
 
 The exported components are wrapped versions of the `Link` and `NavLink` exports of react-router-dom. In some cases you may need to provide a custom `Link` implementation.
 
@@ -80,3 +80,20 @@ const MyComponent = () => (
 );
 ```
 
+## `id` prefix
+
+It can be necessary to use an `id` different from the the hash for the element to scroll to (example when using [fullPage](https://github.com/alvarotrigo/fullPage.js/) as there is a [bug](https://github.com/alvarotrigo/fullPage.js/issues/72) when `id`s have the same values than anchors). To do so you can use the `prefix` prop a such :
+
+```jsx
+<Link
+    to="/path#hash"
+    prefix="prefix"
+>Link to Hash Fragment</Link>
+```
+The element linked will then need to have `prefix-hash` as its id :
+
+```jsx
+<div id="prefix-hash">
+    element to scroll to
+</div>
+```

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Link, NavLink } from 'react-router-dom';
 
 let hashFragment = '';
+let prefix = '';
 let observer = null;
 let asyncTimerId = null;
 let scrollFunction = null;
@@ -17,7 +18,15 @@ function reset() {
 }
 
 function getElAndScroll() {
-  const element = document.getElementById(hashFragment);
+  let element;
+  if (prefix)
+  {
+    element = document.getElementById(`${prefix}-${hashFragment}`);
+  }
+  else
+  {
+    element = document.getElementById(hashFragment);
+  }
   if (element !== null) {
     scrollFunction(element);
     reset();
@@ -60,6 +69,9 @@ export function genericHashLink(props, As) {
       typeof props.to.hash === 'string'
     ) {
       hashFragment = props.to.hash.replace('#', '');
+    }
+    if (typeof props.prefix === 'string' && props.prefix !== '') {
+      prefix = props.prefix;
     }
     if (hashFragment !== '') {
       scrollFunction =


### PR DESCRIPTION
This adds an optional prefix prop so we can use an `id` different than the hash.

It can be necessary to use an `id` different from the the hash for the element to scroll to (example when using [fullPage](https://github.com/alvarotrigo/fullPage.js/) as there is a [bug](https://github.com/alvarotrigo/fullPage.js/issues/72) when `id`s have the same values than anchors).

You can try the build directly with `npm i https://github.com/monkeydri/react-router-hash-link/tarball/id-prefix-build`.