### PR TITLE
Forward refs properly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,46 +46,44 @@ function hashLinkScroll() {
   }, 0);
 }
 
-export function genericHashLink(props, As) {
-  function handleClick(e) {
-    reset();
-    if (props.onClick) props.onClick(e);
-    if (typeof props.to === 'string') {
-      hashFragment = props.to
-        .split('#')
-        .slice(1)
-        .join('#');
-    } else if (
-      typeof props.to === 'object' &&
-      typeof props.to.hash === 'string'
-    ) {
-      hashFragment = props.to.hash.replace('#', '');
+export function genericHashLink(As) {
+  return React.forwardRef((props, ref) => {
+    function handleClick(e) {
+      reset();
+      if (props.onClick) props.onClick(e);
+      if (typeof props.to === 'string') {
+        hashFragment = props.to
+          .split('#')
+          .slice(1)
+          .join('#');
+      } else if (
+        typeof props.to === 'object' &&
+        typeof props.to.hash === 'string'
+      ) {
+        hashFragment = props.to.hash.replace('#', '');
+      }
+      if (hashFragment !== '') {
+        scrollFunction =
+          props.scroll ||
+          (el =>
+            props.smooth
+              ? el.scrollIntoView({ behavior: "smooth" })
+              : el.scrollIntoView());
+        hashLinkScroll();
+      }
     }
-    if (hashFragment !== '') {
-      scrollFunction =
-        props.scroll ||
-        (el =>
-          props.smooth
-            ? el.scrollIntoView({ behavior: "smooth" })
-            : el.scrollIntoView());
-      hashLinkScroll();
-    }
-  }
-  const { scroll, smooth, ...filteredProps } = props;
-  return (
-    <As {...filteredProps} onClick={handleClick}>
-      {props.children}
-    </As>
-  );
+    const { scroll, smooth, ...filteredProps } = props;
+    return (
+      <As {...filteredProps} onClick={handleClick} ref={ref}>
+        {props.children}
+      </As>
+    );
+  });
 }
 
-export function HashLink(props) {
-  return genericHashLink(props, Link);
-}
+export const HashLink = genericHashLink(Link);
 
-export function NavHashLink(props) {
-  return genericHashLink(props, NavLink);
-}
+export const NavHashLink = genericHashLink(NavLink);
 
 const propTypes = {
   onClick: PropTypes.func,


### PR DESCRIPTION
NavHashLink and HashLink need to forward React refs properly. This will enable libraries like Material UI and React Router to be used properly with react-router-hash-link. For an example of where such behavior is needed, see [this demo](https://material-ui.com/guides/composition/#caveat-with-inlining). The Material UI ListItem needs a ref to the root element provided by NavLink so it can focus it (as you can see from the [source code](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItem/ListItem.js)).