### PR TITLE
Handle "active" class when <NavHashLink to="#" />

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,10 +90,7 @@ export function genericHashLink(As) {
     const passDownProps = {};
     if (As === NavLink) {
       passDownProps.isActive = (match, location) => {
-        let locationHash = location.hash;
-        if (location.hash === '') {
-          locationHash = '#';
-        }
+        const locationHash = location.hash === '' ? '#' : location.hash;
         return match && match.isExact && locationHash === linkHash;
       };
     }

--- a/src/index.js
+++ b/src/index.js
@@ -89,8 +89,13 @@ export function genericHashLink(As) {
 
     const passDownProps = {};
     if (As === NavLink) {
-      passDownProps.isActive = (match, location) =>
-        match && match.isExact && location.hash === linkHash;
+      passDownProps.isActive = (match, location) => {
+        let locationHash = location.hash;
+        if (location.hash === '') {
+          locationHash = '#';
+        }
+        return match && match.isExact && locationHash === linkHash;
+      };
     }
 
     function handleClick(e) {


### PR DESCRIPTION
When having a NavHashLink linking to the top of the page using "#" anchor, the active class is not set.

This PR aims at fixing this issue.