### PR TITLE
Allow focus to remain on the targets of hash links when the target is focusable

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,9 @@ const MyComponent = () => (
   </div>
 );
 ```
+
+## Focus Management
+
+`react-router-hash-link` attempts to recreate the native browser focusing behavior as closely as possible. For non-interactive elements, it calls `element.focus()` followed by `element.blur()` (using a temporary `tabindex` to ensure that the element can be focused programmatically) so that focus _moves_ to the target element but does not remain on it or trigger any style changes. For interactive elements, it calls `element.focus()` and leaves focus on the target element.
+
+If you would like to leave focus on a non-interactive element - for example, to augment the navigation interaction with a visual focus indicator - you can optionally set a `tabindex` on the target element. `react-router-hash-link` will respect the `tabindex` and leave focus on the target in that case.

--- a/src/index.js
+++ b/src/index.js
@@ -17,8 +17,10 @@ function reset() {
 }
 
 function isInteractiveElement(element) {
-  const interactiveTags = ['A', 'AREA', 'BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'];
-  return interactiveTags.includes(element.tagName) && !element.hasAttribute('disabled');
+  const formTags = ['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'];
+  const linkTags = ['A', 'AREA'];
+  return (formTags.includes(element.tagName) && !element.hasAttribute('disabled'))
+    || (linkTags.includes(element.tagName) && element.hasAttribute('href'));
 }
 
 function getElAndScroll() {

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ function reset() {
 }
 
 function isInteractiveElement(element) {
-  const interactiveTags = ['A', 'BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'];
+  const interactiveTags = ['A', 'AREA', 'BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'];
   return interactiveTags.includes(element.tagName) && !element.hasAttribute('disabled');
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,11 @@ function reset() {
   }
 }
 
+function isInteractiveElement(element) {
+  const interactiveTags = ['A', 'BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'];
+  return interactiveTags.includes(element.tagName) && !element.hasAttribute('disabled');
+}
+
 function getElAndScroll() {
   let element = null;
   if (hashFragment === '#') {
@@ -43,11 +48,16 @@ function getElAndScroll() {
     let originalTabIndex = element.getAttribute('tabindex');
     if (originalTabIndex === null) element.setAttribute('tabindex', -1);
     element.focus({ preventScroll: true });
-    // for some reason calling blur() in safari resets the focus region to where it was previously,
-    // if blur() is not called it works in safari, but then are stuck with default focus styles
-    // on an element that otherwise might never had focus styles applied, so not an option
-    element.blur();
-    if (originalTabIndex === null) element.removeAttribute('tabindex');
+    if (originalTabIndex === null) {
+      if (!isInteractiveElement(element)) {
+        // for some reason calling blur() in safari resets the focus region to where it was previously,
+        // if blur() is not called it works in safari, but then are stuck with default focus styles
+        // on an element that otherwise might never had focus styles applied, so not an option
+        element.blur();
+      }
+
+      element.removeAttribute('tabindex');
+    }
 
     reset();
     return true;


### PR DESCRIPTION
This PR makes the `element.blur()` call after the focus handling conditional depending on whether or not the element itself is focusable, either natively or by the presence of a tabindex. 

1. In the first case - if the element is a natively focusable element - leaving focus on the element brings the behavior closer to the native behavior for hash links. Linking directly to an interactive control is probably less common than linking to, say, headings, but it seems like a benefit to handle this case.
2. In the second, consumers of this module can choose to leave focus on non-interactive elements by setting a tabindex on them. Therefore, it will work as before by default, but developers looking to add focus styles can opt in by setting that tabindex.

I'm most interested in the second case for the site I'm working in. We're leaning toward displaying focus visually for in-page navigation events as discussed in https://github.com/w3c/wcag/issues/1001, or at least exploring that option. This change allows us to remove our workaround click handlers that manage focus while still getting a visual focus indicator on target headings by leaving a `tabIndex={-1}` on those headings, so we can take advantage of the focus handling from https://github.com/rafgraph/react-router-hash-link/commit/d57be4898b4d2e20afca029db7d218bb7001411b while still keeping that flexibility.

Any feedback is welcome, and thank you for your work on this project.