### PR TITLE
change host address (doesn't work on Windows)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "npm link react-router-hash-link && npm start",
     "devCleanup": "npm install --save react-router-hash-link@latest",
-    "start": "webpack-dev-server --host 0.0.0.0 --disable-host-check --history-api-fallback --open",
+    "start": "webpack-dev-server --host 127.0.0.1 --disable-host-check --history-api-fallback --open",
     "build": "npm run devCleanup && rm -rf build && webpack -p"
   },
   "repository": {


### PR DESCRIPTION
npm run dev doesn't work for me (Windows). 127.0.0.1 looks good.
also https://en.wikipedia.org/wiki/0.0.0.0 says "0.0.0.0 is a non-routable meta-address used to designate an invalid, unknown or non-applicable target"