### PR TITLE
Make it possible to opt out of focus handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ const MyComponent = () => (
 
 ## Focus Management
 
-`react-router-hash-link` attempts to recreate the native browser focusing behavior as closely as possible
+`react-router-hash-link` attempts to recreate the native browser focusing behavior as closely as possible.
 
 The browser native behavior when clicking a hash link is:
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,6 @@ To recreate this `react-router-hash-link` does the following:
 
 Note that you may find it useful to leave focus on non-interactive elements (by adding a `tabindex` of `-1`) to augment the navigation action with a visual focus indicator.
 
-### `handleFocus: boolean`
+### `preventFocusHandling: boolean`
 
-- Optionally disable the focus handling
+- Optionally prevent the default focus handling

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ const MyComponent = () => (
 
 ## Focus Management
 
-`react-router-hash-link` attempts to recreate the native browser focusing behavior as closely as possible.
+`react-router-hash-link` attempts to recreate the native browser focusing behavior as closely as possible
 
 The browser native behavior when clicking a hash link is:
 
@@ -165,3 +165,7 @@ To recreate this `react-router-hash-link` does the following:
 - For focusable elements, it calls `element.focus()` and leaves focus on the target element.
 
 Note that you may find it useful to leave focus on non-interactive elements (by adding a `tabindex` of `-1`) to augment the navigation action with a visual focus indicator.
+
+### `handleFocus: boolean`
+
+- Optionally disable the focus handling

--- a/src/HashLink.jsx
+++ b/src/HashLink.jsx
@@ -21,7 +21,8 @@ function isInteractiveElement(element) {
   const linkTags = ['A', 'AREA'];
   return (
     (formTags.includes(element.tagName) && !element.hasAttribute('disabled')) ||
-    (linkTags.includes(element.tagName) && element.hasAttribute('href'))
+    (linkTags.includes(element.tagName) && element.hasAttribute('href')) ||
+    element.isContentEditable
   );
 }
 

--- a/src/HashLink.jsx
+++ b/src/HashLink.jsx
@@ -6,9 +6,11 @@ let hashFragment = '';
 let observer = null;
 let asyncTimerId = null;
 let scrollFunction = null;
+let preventFocusHandling = false;
 
 function reset() {
   hashFragment = '';
+  preventFocusHandling = false;
   if (observer !== null) observer.disconnect();
   if (asyncTimerId !== null) {
     window.clearTimeout(asyncTimerId);
@@ -26,7 +28,7 @@ function isInteractiveElement(element) {
   );
 }
 
-function getElAndScroll(preventFocusHandling) {
+function getElAndScroll() {
   let element = null;
   if (hashFragment === '#') {
     // use document.body instead of document.documentElement because of a bug in smoothscroll-polyfill in safari
@@ -71,12 +73,12 @@ function getElAndScroll(preventFocusHandling) {
   return false;
 }
 
-function hashLinkScroll(timeout, preventFocusHandling) {
+function hashLinkScroll(timeout) {
   // Push onto callback queue so it runs after the DOM is updated
   window.setTimeout(() => {
-    if (getElAndScroll(preventFocusHandling) === false) {
+    if (getElAndScroll() === false) {
       if (observer === null) {
-        observer = new MutationObserver(() => getElAndScroll(preventFocusHandling));
+        observer = new MutationObserver(getElAndScroll);
       }
       observer.observe(document, {
         attributes: true,
@@ -112,6 +114,7 @@ export function genericHashLink(As) {
     function handleClick(e) {
       reset();
       hashFragment = props.elementId ? `#${props.elementId}` : linkHash;
+      preventFocusHandling = !!props.preventFocusHandling;
       if (props.onClick) props.onClick(e);
       if (
         hashFragment !== '' &&
@@ -128,7 +131,7 @@ export function genericHashLink(As) {
             props.smooth
               ? el.scrollIntoView({ behavior: 'smooth' })
               : el.scrollIntoView());
-        hashLinkScroll(props.timeout, props.preventFocusHandling);
+        hashLinkScroll(props.timeout);
       }
     }
     const { scroll, smooth, timeout, elementId, preventFocusHandling, ...filteredProps } = props;

--- a/src/HashLink.jsx
+++ b/src/HashLink.jsx
@@ -26,7 +26,7 @@ function isInteractiveElement(element) {
   );
 }
 
-function getElAndScroll(handleFocus) {
+function getElAndScroll(preventFocusHandling) {
   let element = null;
   if (hashFragment === '#') {
     // use document.body instead of document.documentElement because of a bug in smoothscroll-polyfill in safari
@@ -48,7 +48,7 @@ function getElAndScroll(handleFocus) {
   if (element !== null) {
     scrollFunction(element);
 
-    if (handleFocus) {
+    if (!preventFocusHandling) {
       // update focus to where the page is scrolled to
       // unfortunately this doesn't work in safari (desktop and iOS) when blur() is called
       let originalTabIndex = element.getAttribute('tabindex');
@@ -71,12 +71,12 @@ function getElAndScroll(handleFocus) {
   return false;
 }
 
-function hashLinkScroll(timeout, handleFocus) {
+function hashLinkScroll(timeout, preventFocusHandling) {
   // Push onto callback queue so it runs after the DOM is updated
   window.setTimeout(() => {
-    if (getElAndScroll(handleFocus) === false) {
+    if (getElAndScroll(preventFocusHandling) === false) {
       if (observer === null) {
-        observer = new MutationObserver(() => getElAndScroll(handleFocus));
+        observer = new MutationObserver(() => getElAndScroll(preventFocusHandling));
       }
       observer.observe(document, {
         attributes: true,
@@ -128,10 +128,10 @@ export function genericHashLink(As) {
             props.smooth
               ? el.scrollIntoView({ behavior: 'smooth' })
               : el.scrollIntoView());
-        hashLinkScroll(props.timeout, props.handleFocus);
+        hashLinkScroll(props.timeout, props.preventFocusHandling);
       }
     }
-    const { scroll, smooth, timeout, elementId, handleFocus, ...filteredProps } = props;
+    const { scroll, smooth, timeout, elementId, preventFocusHandling, ...filteredProps } = props;
     return (
       <As {...passDownProps} {...filteredProps} onClick={handleClick} ref={ref}>
         {props.children}
@@ -155,7 +155,7 @@ if (process.env.NODE_ENV !== 'production') {
     timeout: PropTypes.number,
     elementId: PropTypes.string,
     to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-    handleFocus: PropTypes.bool,
+    preventFocusHandling: PropTypes.bool,
   };
 
   HashLink.propTypes = propTypes;


### PR DESCRIPTION
Possible bonus: Regard contenteditables as interactive elements, but I understand if you don’t want this as part of the same PR, or have considered this before and concluded that it’s best to leave them out.

I’m not entirely sure about the flow of arguments here and whether it could be simplified or flow in a more natural way, but it seems to be working as intended.

Fixes #89